### PR TITLE
[REF] remove inactive members (1/2)

### DIFF
--- a/conf/psc/connector.yml
+++ b/conf/psc/connector.yml
@@ -31,7 +31,6 @@ connector-lims-maintainers-psc-representative:
 connector-magento-maintainers:
   members:
     - guewen
-    - OSguard
   name: Connector magento maintainers
   representatives:
     - simahawk

--- a/conf/psc/connector.yml
+++ b/conf/psc/connector.yml
@@ -58,7 +58,6 @@ connector-maintainers-psc-representative:
 connector-odoo2odoo:
   members:
     - ajite
-    - elicoidal
     - maljac
   name:
     Team dedicated to inter Company operations (icops) using odoo Connector technology

--- a/conf/psc/infrastructure.yml
+++ b/conf/psc/infrastructure.yml
@@ -1,5 +1,4 @@
 infrastructure-maintainer:
-  members:
-    - elicoidal
+  members: []
   name: Maintainer of the infrastructure repositories
   representatives: []

--- a/conf/psc/intercompany.yml
+++ b/conf/psc/intercompany.yml
@@ -1,13 +1,11 @@
 intercompany-maintainers:
   members:
-    - elicoidal
     - JordiBForgeFlow
   name: Intercompany maintainers
   representatives:
     - jgrandguillaume
     - gurneyalex
 intercompany-maintainers-psc-representative:
-  members:
-    - elicoidal
+  members: []
   name: Intercompany maintainers psc representative
   representatives: []

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -100,13 +100,11 @@ local-chile-maintainers-psc-representative:
   name: Local chile maintainers psc representative
   representatives: []
 local-china-maintainers:
-  members:
-    - elicoidal
+  members: []
   name: Local china maintainers
   representatives: []
 local-china-maintainers-psc-representative:
-  members:
-    - elicoidal
+  members: []
   name: Local china maintainers psc representative
   representatives: []
 local-colombia-maintainers:
@@ -524,7 +522,6 @@ local-turkey-maintainers-psc-representative:
   representatives: []
 local-uk-maintainers:
   members:
-    - elicoidal
     - nuria-opusvl
   name: United kingdom localization team
   representatives: []

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -211,7 +211,6 @@ local-france-maintainers-psc-representative:
   representatives: []
 local-germany-maintainers:
   members:
-    - OSguard
     - tv-openbig
   name: Local germany maintainers
   representatives: []

--- a/conf/psc/oca.yml
+++ b/conf/psc/oca.yml
@@ -2,7 +2,6 @@ oca-apps-store:
   members:
     - orentol
     - bizzappdev
-    - elicoidal
     - astirpe
     - espo-tony
   name: Oca Apps Store

--- a/conf/psc/pos.yml
+++ b/conf/psc/pos.yml
@@ -1,6 +1,5 @@
 pos-maintainers:
   members:
-    - OSguard
     - alexis-via
     - Fkawala
     - ivantodorovich

--- a/conf/psc/tools.yml
+++ b/conf/psc/tools.yml
@@ -3,7 +3,6 @@ tools-maintainers:
     - guewen
     - lmignon
     - yajo
-    - OSguard
     - thomaspaulb
     - hbrunn
     - legalsylvain

--- a/conf/psc/web.yml
+++ b/conf/psc/web.yml
@@ -4,7 +4,6 @@ web-maintainers:
     - Tardo
     - yajo
     - StefanRijnhart
-    - OSguard
     - hbrunn
     - legalsylvain
     - yvaucher

--- a/conf/psc/website.yml
+++ b/conf/psc/website.yml
@@ -3,7 +3,6 @@ website-maintainers:
     - nhomar
     - guewen
     - yajo
-    - OSguard
     - antespi
     - hbrunn
     - pedrobaeza
@@ -14,7 +13,6 @@ website-maintainers:
   representatives:
     - simahawk
 website-maintainers-psc-representative:
-  members:
-    - OSguard
+  members: []
   name: Website maintainers psc representative
   representatives: []


### PR DESCRIPTION
Hi all.

I have the feeling that the list of maintainers is not at all up to date. I mean, some people don't participate at all in the repo they're supposed to maintain, or even don't contribute at all to the OCA (review / comment / contribution / etc...).

Current PR : 
- remove @elicoidal, who passed away a few years ago.
- remove @OSguard, who left odoo ecosystem 6 years ago

I made a script to identify maintainers who hadn't had a single interaction on github in 1 year. (not a comment, not a commit). here is the list. do you mind if I make another PR to remove these people? Thanks ! 

- @albariera
- @Capriatto
- @carlosrve
- @CharlineDumontet
- @coodec
- @DayssamAgora
- @ddico
- @duanyp1991
- @Ehtaga
- @eugen-don
- @EvvFoxy
- @fblauer
- @FFernandez-PlanetaTIC
- @Fouad-AGORA
- @gmader
- @ierrajai
- @jgrandguillaume
- @kloss17
- @labaggio
- @lauracvilla-zz
- @lucmaurer
- @mathi123
- @mbelaid
- @mmalorni
- @nuria-opusvl
- @okuryan
- @plamarche
- @RBelfiore
- @redarouichi
- @rgarnau
- @sebastiken
- @stephankeller
- @YannickB
- @Ylemoing