### PR TITLE
[REF] remove inactive members (2/2)

### DIFF
--- a/conf/psc/accounting.yml
+++ b/conf/psc/accounting.yml
@@ -16,7 +16,6 @@ accounting-maintainers:
     - joao-p-marques
   name: Accounting maintainers
   representatives:
-    - jgrandguillaume
     - sbidoul
 accounting-maintainers-psc-representative:
   members:

--- a/conf/psc/community.yml
+++ b/conf/psc/community.yml
@@ -8,7 +8,6 @@ community-maintainers:
     - joao-p-marques
   name: Responsible of the maintainer Tools and maintainer Quality Tools repos
   representatives:
-    - jgrandguillaume
     - simahawk
     - sbidoul
     - dreispt

--- a/conf/psc/connector.yml
+++ b/conf/psc/connector.yml
@@ -82,7 +82,6 @@ connector-saleforce-maintainers:
     - yvaucher
   name: Connector saleforce maintainers
   representatives:
-    - jgrandguillaume
     - gurneyalex
 connector-spscommerce:
   members:

--- a/conf/psc/connector.yml
+++ b/conf/psc/connector.yml
@@ -67,7 +67,6 @@ connector-prestashop-maintainers:
     - flachica
     - arthru
     - sebastienbeau
-    - FFernandez-PlanetaTIC
   name: Connector prestashop maintainers
   representatives:
     - simahawk

--- a/conf/psc/core.yml
+++ b/conf/psc/core.yml
@@ -11,7 +11,6 @@ core-maintainers:
     - pedrobaeza
   name: Core maintainers
   representatives:
-    - jgrandguillaume
     - simahawk
     - sbidoul
     - dreispt

--- a/conf/psc/crm.yml
+++ b/conf/psc/crm.yml
@@ -12,7 +12,6 @@ crm-sales-marketing-maintainers:
     - HaraldPanten
   name: Crm, sales & marketing maintainers
   representatives:
-    - jgrandguillaume
     - simahawk
     - gurneyalex
 crm-sales-marketing-maintainers-psc-representative:

--- a/conf/psc/donation.yml
+++ b/conf/psc/donation.yml
@@ -1,7 +1,6 @@
 donation-maintainers:
   members:
     - alexis-via
-    - albariera
   name: Donation maintainers
   representatives: []
 donation-maintainers-psc-representative:

--- a/conf/psc/dotnet.yml
+++ b/conf/psc/dotnet.yml
@@ -1,10 +1,8 @@
 dotnet-maintainers:
-  members:
-    - mathi123
+  members: []
   name: Dotnet maintainers
   representatives: []
 dotnet-maintainers-psc-representative:
-  members:
-    - mathi123
+  members: []
   name: Dotnet maintainers psc representative
   representatives: []

--- a/conf/psc/human.yml
+++ b/conf/psc/human.yml
@@ -8,7 +8,6 @@ human-resources-maintainers:
     - Saran440
   name: Human resources maintainers
   representatives:
-    - jgrandguillaume
     - dreispt
     - gurneyalex
 human-resources-maintainers-psc-representative:

--- a/conf/psc/human.yml
+++ b/conf/psc/human.yml
@@ -6,7 +6,6 @@ human-resources-maintainers:
     - feketemihai
     - nimarosa
     - Saran440
-    - albariera
   name: Human resources maintainers
   representatives:
     - jgrandguillaume

--- a/conf/psc/intercompany.yml
+++ b/conf/psc/intercompany.yml
@@ -4,7 +4,6 @@ intercompany-maintainers:
     - legalsylvain
   name: Intercompany maintainers
   representatives:
-    - jgrandguillaume
     - gurneyalex
 intercompany-maintainers-psc-representative:
   members: []

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -147,14 +147,12 @@ local-el-salvador-maintainers:
 local-estonia-maintainers:
   members:
     - alexey-pelykh
-    - okuryan
     - veryberry
     - nedaszilinskas
   name: Local estonia maintainers
   representatives: []
 local-estonia-maintainers-psc-representative:
-  members:
-    - okuryan
+  members: []
   name: Local estonia maintainers psc representative
   representatives: []
 local-ethiopia-maintainers:
@@ -252,13 +250,11 @@ local-iran-maintainers-psc-representative:
   name: Local iran maintainers psc representative
   representatives: []
 local-ireland-maintainers:
-  members:
-    - okuryan
+  members: []
   name: Local ireland maintainers
   representatives: []
 local-ireland-maintainers-psc-representative:
-  members:
-    - okuryan
+  members: []
   name: Local ireland maintainers psc representative
   representatives: []
 local-italy-developers:

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -339,8 +339,7 @@ local-mexico-maintainers-psc-representative:
   name: Local mexico maintainers psc representative
   representatives: []
 local-morocco-maintainers:
-  members:
-    - redarouichi
+  members: []
   name: Local morocco maintainers
   representatives: []
 local-morocco-maintainers-psc-representative:

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -357,7 +357,6 @@ local-morocco-maintainers:
     - Fouad-AGORA
     - ierrajai
     - redarouichi
-    - DayssamAgora
   name: Local morocco maintainers
   representatives: []
 local-morocco-maintainers-psc-representative:

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -80,7 +80,6 @@ local-canada-maintainers:
     - joaoalf
     - fblauer
     - mmalorni
-    - Ehtaga
   name: Local canada maintainers
   representatives: []
 local-canada-maintainers-psc-representative:

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -498,8 +498,7 @@ local-turkey-maintainers-psc-representative:
   name: Local turkey maintainers psc representative
   representatives: []
 local-uk-maintainers:
-  members:
-    - nuria-opusvl
+  members: []
   name: United kingdom localization team
   representatives: []
 local-ukraine-maintainers:

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -539,7 +539,6 @@ local-usa-maintainers:
     - max3903
     - thinkwelltwd
     - stephankeller
-    - gmader
   name: Local usa maintainers
   representatives: []
 local-usa-maintainers-psc-representative:

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -118,13 +118,11 @@ local-colombia-maintainers-psc-representative:
   name: Local colombia maintainers psc representative
   representatives: []
 local-costa-rica-maintainers:
-  members:
-    - carlosrve
+  members: []
   name: Local costa Rica maintainers
   representatives: []
 local-costa-rica-maintainers-psc-representative:
-  members:
-    - carlosrve
+  members: []
   name: Local costa Rica maintainers psc representative
   representatives: []
 local-croatia-maintainers:

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -139,12 +139,10 @@ local-croatia-maintainers-psc-representative:
 local-ecuador-maintainers:
   members:
     - celm1990
-    - coodec
   name: Local ecuador maintainers
   representatives: []
 local-ecuador-maintainers-psc-representative:
-  members:
-    - coodec
+  members: []
   name: Local ecuador maintainers psc representative
   representatives: []
 local-el-salvador-maintainers:

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -182,8 +182,7 @@ local-finland-maintainers-project-leader:
   members:
     - jarmokortetjarvi
   name: Local finland maintainers project leader
-  representatives:
-    - jgrandguillaume
+  representatives: []
 local-finland-maintainers-psc-representative:
   members: []
   name: Local finland maintainers psc representative
@@ -210,8 +209,7 @@ local-germany-maintainers-project-leader:
   members:
     - tv-openbig
   name: Local germany maintainers project leader
-  representatives:
-    - jgrandguillaume
+  representatives: []
 local-germany-maintainers-psc-representative:
   members:
     - tv-openbig
@@ -470,8 +468,7 @@ local-switzerland-maintainers:
     - fclementic2c
     - ecino
   name: Local switzerland maintainers
-  representatives:
-    - jgrandguillaume
+  representatives: []
 local-switzerland-maintainers-psc-representative:
   members:
     - yvaucher

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -144,7 +144,6 @@ local-ecuador-maintainers-psc-representative:
 local-el-salvador-maintainers:
   members:
     - JoanMarin
-    - lauracvilla-zz
   name: El salvador localization maintainers
   representatives:
     - grottas

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -460,7 +460,6 @@ local-switzerland-maintainers:
     - vrenaville
     - TDu
     - yvaucher
-    - lucmaurer
     - fclementic2c
     - ecino
   name: Local switzerland maintainers

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -275,7 +275,6 @@ local-italy-developers:
     - sergiocorato
     - scigghia
     - MarcoCalcagni
-    - labaggio
     - francesco-ooops
   name:
     Team only used for notifications. see https://github.com/oca/l10n Italy/wiki/team
@@ -292,7 +291,6 @@ local-italy-maintainers:
     - tafaRU
     - sergiocorato
     - alessandrocamilli
-    - labaggio
     - francesco-ooops
   name: Local italy maintainers
   representatives: []

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -253,13 +253,11 @@ local-indonesia-maintainers-psc-representative:
   representatives: []
 local-iran-maintainers:
   members:
-    - duanyp1991
     - saeed-raeisi
   name: Local iran maintainers
   representatives: []
 local-iran-maintainers-psc-representative:
-  members:
-    - duanyp1991
+  members: []
   name: Local iran maintainers psc representative
   representatives: []
 local-ireland-maintainers:

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -1,7 +1,6 @@
 local-argentina-maintainers:
   members:
     - sebastiken
-    - kloss17
     - nimarosa
     - RBelfiore
   name: Local argentina maintainers

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -78,7 +78,6 @@ local-cambodia-maintainers-psc-representative:
 local-canada-maintainers:
   members:
     - joaoalf
-    - fblauer
     - mmalorni
   name: Local canada maintainers
   representatives: []

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -349,7 +349,6 @@ local-mexico-maintainers-psc-representative:
 local-morocco-maintainers:
   members:
     - mbelaid
-    - ierrajai
     - redarouichi
   name: Local morocco maintainers
   representatives: []

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -81,7 +81,6 @@ local-canada-maintainers:
     - fblauer
     - mmalorni
     - Ehtaga
-    - ddico
   name: Local canada maintainers
   representatives: []
 local-canada-maintainers-psc-representative:

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -1,6 +1,5 @@
 local-argentina-maintainers:
   members:
-    - sebastiken
     - nimarosa
   name: Local argentina maintainers
   representatives: []

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -77,7 +77,6 @@ local-cambodia-maintainers-psc-representative:
 local-canada-maintainers:
   members:
     - joaoalf
-    - mmalorni
   name: Local canada maintainers
   representatives: []
 local-canada-maintainers-psc-representative:
@@ -342,13 +341,11 @@ local-mexico-maintainers-psc-representative:
   representatives: []
 local-morocco-maintainers:
   members:
-    - mbelaid
     - redarouichi
   name: Local morocco maintainers
   representatives: []
 local-morocco-maintainers-psc-representative:
-  members:
-    - mbelaid
+  members: []
   name: Local morocco maintainers psc representative
   representatives: []
 local-netherlands-maintainers:

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -151,7 +151,6 @@ local-ecuador-maintainers-psc-representative:
   representatives: []
 local-el-salvador-maintainers:
   members:
-    - Capriatto
     - JoanMarin
     - lauracvilla-zz
   name: El salvador localization maintainers

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -2,7 +2,6 @@ local-argentina-maintainers:
   members:
     - sebastiken
     - nimarosa
-    - RBelfiore
   name: Local argentina maintainers
   representatives: []
 local-argentina-maintainers-psc-representative:

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -349,7 +349,6 @@ local-mexico-maintainers-psc-representative:
 local-morocco-maintainers:
   members:
     - mbelaid
-    - Fouad-AGORA
     - ierrajai
     - redarouichi
   name: Local morocco maintainers

--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -522,7 +522,6 @@ local-usa-maintainers:
   members:
     - max3903
     - thinkwelltwd
-    - stephankeller
   name: Local usa maintainers
   representatives: []
 local-usa-maintainers-psc-representative:

--- a/conf/psc/logistics.yml
+++ b/conf/psc/logistics.yml
@@ -12,7 +12,6 @@ logistics-maintainers:
     - ps-tubtim
   name: Logistics maintainers
   representatives:
-    - jgrandguillaume
     - simahawk
     - gurneyalex
 logistics-maintainers-psc-representative:

--- a/conf/psc/management.yml
+++ b/conf/psc/management.yml
@@ -2,7 +2,6 @@ management-systems-maintainers:
   members:
     - max3903
     - ivantodorovich
-    - eugen-don
   name: Management systems maintainers
   representatives:
     - dreispt

--- a/conf/psc/procurement.yml
+++ b/conf/psc/procurement.yml
@@ -9,7 +9,6 @@ procurement-purchase-maintainers:
     - HaraldPanten
   name: Procurement & purchase maintainers
   representatives:
-    - jgrandguillaume
     - gurneyalex
 procurement-purchase-maintainers-psc-representative:
   members: []

--- a/conf/psc/product.yml
+++ b/conf/psc/product.yml
@@ -5,7 +5,6 @@ product-maintainers:
     - rousseldenis
   name: Product maintainers
   representatives:
-    - jgrandguillaume
     - gurneyalex
 product-maintainers-psc-representative:
   members: []

--- a/conf/psc/project.yml
+++ b/conf/psc/project.yml
@@ -17,7 +17,6 @@ project-service-maintainers:
     - AaronHForgeFlow
   name: Contract management core editors and project core editors
   representatives:
-    - jgrandguillaume
     - simahawk
     - dreispt
     - gurneyalex

--- a/conf/psc/role.yml
+++ b/conf/psc/role.yml
@@ -1,7 +1,6 @@
 role-policy-maintainers:
   members:
     - joaoalf
-    - mmalorni
     - pankk
     - luc-demeyer
   name: Role policy maintainers

--- a/conf/psc/role.yml
+++ b/conf/psc/role.yml
@@ -4,7 +4,6 @@ role-policy-maintainers:
     - fblauer
     - mmalorni
     - pankk
-    - EvvFoxy
     - luc-demeyer
   name: Role policy maintainers
   representatives: []

--- a/conf/psc/role.yml
+++ b/conf/psc/role.yml
@@ -1,7 +1,6 @@
 role-policy-maintainers:
   members:
     - joaoalf
-    - fblauer
     - mmalorni
     - pankk
     - luc-demeyer

--- a/conf/psc/role.yml
+++ b/conf/psc/role.yml
@@ -3,7 +3,6 @@ role-policy-maintainers:
     - joaoalf
     - fblauer
     - mmalorni
-    - Ehtaga
     - pankk
     - EvvFoxy
     - luc-demeyer

--- a/conf/psc/role.yml
+++ b/conf/psc/role.yml
@@ -7,7 +7,6 @@ role-policy-maintainers:
     - pankk
     - EvvFoxy
     - luc-demeyer
-    - ddico
   name: Role policy maintainers
   representatives: []
 role-policy-maintainers-psc-representative:

--- a/conf/psc/vertical.yml
+++ b/conf/psc/vertical.yml
@@ -33,18 +33,15 @@ vertical-association-maintainers-psc-representative:
   name: Vertical association maintainers psc representative
   representatives: []
 vertical-community-maintainers:
-  members:
-    - YannickB
+  members: []
   name: Vertical community maintainers
   representatives: []
 vertical-community-maintainers-project-leader:
-  members:
-    - YannickB
+  members: []
   name: Vertical community maintainers project leader
   representatives: []
 vertical-community-maintainers-psc-representative:
-  members:
-    - YannickB
+  members: []
   name: Vertical community maintainers psc representative
   representatives: []
 vertical-construction-maintainers:

--- a/conf/psc/vertical.yml
+++ b/conf/psc/vertical.yml
@@ -41,8 +41,7 @@ vertical-community-maintainers-project-leader:
   members:
     - YannickB
   name: Vertical community maintainers project leader
-  representatives:
-    - jgrandguillaume
+  representatives: []
 vertical-community-maintainers-psc-representative:
   members:
     - YannickB
@@ -119,7 +118,6 @@ vertical-ngo-maintainers:
   members: []
   name: Vertical ngo maintainers
   representatives:
-    - jgrandguillaume
     - gurneyalex
 vertical-ngo-maintainers-psc-representative:
   members: []

--- a/conf/psc/vertical.yml
+++ b/conf/psc/vertical.yml
@@ -159,7 +159,6 @@ vertical-rental-psc-representative:
 vertical-travel-maintainers:
   members:
     - max3903
-    - plamarche
   name: Vertical travel maintainers
   representatives: []
 vertical-travel-maintainers-psc-representative:

--- a/conf/psc/vertical.yml
+++ b/conf/psc/vertical.yml
@@ -50,7 +50,6 @@ vertical-community-maintainers-psc-representative:
 vertical-construction-maintainers:
   members:
     - max3903
-    - mathi123
   name: Vertical construction maintainers
   representatives: []
 vertical-construction-maintainers-psc-representative:

--- a/conf/psc/vertical.yml
+++ b/conf/psc/vertical.yml
@@ -105,7 +105,6 @@ vertical-isp-maintainers-psc-representative:
 vertical-medical-maintainers:
   members:
     - nhomar
-    - rgarnau
     - etobella
   name: Vertical medical maintainers
   representatives: []

--- a/conf/psc/web.yml
+++ b/conf/psc/web.yml
@@ -12,7 +12,6 @@ web-maintainers:
     - etobella
   name: Web maintainers
   representatives:
-    - jgrandguillaume
     - simahawk
     - gurneyalex
 web-maintainers-psc-representative:


### PR DESCRIPTION
* Based on top of https://github.com/OCA/repo-maintainer-conf/pull/9. Please merge before the other one.

*  Remove people listed in the previous issue. except :
    * @CharlineDumontet (recent member of oca-consultants)
    * @Ylemoing (recent member of oca-consultants)
    * @jgrandguillaume removed from all the psc, except the board one

**Removal :** 

* [REM] Remove @YannickB. (no activity since June 2022)
* [REM] Remove @stephankeller. (no activity since February 2016)
* [REM] Remove @sebastiken. (no activity since September 2021)
* [REM] Remove @rgarnau. (no activity since March 2018)
* [REM] Remove @redarouichi. (no activity since January 2016)
* [REM] Remove @RBelfiore. (no activity since April 2022)
* [REM] Remove @plamarche. (no activity since April 2016)
* [REM] Remove @okuryan. (no activity since August 2022)
* [REM] Remove @nuria-opusvl. (no activity since October 2015)
* [REM] Remove @mmalorni. (no activity since March 2020)
* [REM] Remove @mathi123. (no activity since August 2022)
* [REM] Remove @lucmaurer. (no activity since April 2022)
* [REM] Remove @lauracvilla-zz. (no activity since February 2020)
* [REM] Remove @labaggio. (no activity since March 2021)
* [REM] Remove @kloss17. (no activity since March 2021)
* [REM] Remove @jgrandguillaume. (no activity since July 2022)
* [REM] Remove @ierrajai. (no activity since January 2016)
* [REM] Remove @gmader. (no activity since October 2017)
* [REM] Remove @Fouad-AGORA. (no activity since January 2016)
* [REM] Remove @FFernandez-PlanetaTIC. (no activity since March 2020)
* [REM] Remove @fblauer. (no activity since November 2022)
* [REM] Remove @EvvFoxy. (no activity since February 2022)
* [REM] Remove @eugen-don. (no activity since December 2017)
* [REM] Remove @Ehtaga. (no activity since July 2018)
* [REM] Remove @duanyp1991. (no activity since September 2018)
* [REM] Remove @ddico. (no activity since September 2022)
* [REM] Remove @DayssamAgora. (no activity since March 2016)
* [REM] Remove @coodec. (no activity since April 2017)
* [REM] Remove @carlosrve. (no activity since September 2021)
* [REM] Remove @Capriatto. (no activity since May 2022)
* [REM] Remove @albariera. (no activity since July 2022)

**Rational :** 

* there are many people defined as responsible of repo, that are no longer active since a lot of time. 
* For the analyis, I listed the people that did'nt do a single "activity" on github since at least a year. It means, no PR, no commit, no comment on any issue or PR.
* Having ghost representatives present a number of problems for me : 
    *  Theoritical security problems. It's quite annoying to have inactive people having merge / adminitration right on OCA repos.
    *  at the moment, it looks as if people are taking care of the repos, when they're not. Sometimes people are pinged but don't respond, which creates a bad experience for contributors.
    * Furthermore, if you clean up these inactive managers, you'll find that some repos have been completely abandoned. This may raise questions. (Ex: github.com/OCA/dotnet, vertical-community, l10n-morocco)
    * If there are PSC without members, maybe this will encourage new people to apply to take care of the repos.

**Important Note :** 
- Just because we're withdrawing names doesn't mean these people aren't otherwise involved in the OCA.
- if people want to reinvest in a functional area later on, that's perfectly possible. Especially since the creation of repo-maintainer-conf, it's very quick to do.