### PR TITLE
[ADD] legalsylvain as member of product-maintainers

### DIFF
--- a/conf/psc/product.yml
+++ b/conf/psc/product.yml
@@ -3,6 +3,7 @@ product-maintainers:
     - jjscarafia
     - JordiBForgeFlow
     - rousseldenis
+    - legalsylvain
   name: Product maintainers
   representatives:
     - gurneyalex


### PR DESCRIPTION
Hi. 
Propose to add me as member of product-maintainers team.

Author of the following 7 modules : 

- product_standard_price_tax_included, product_uom_use_type, product_category_type, product_uom_po_domain, product_net_weight, product_uom_measure_type, product_print_category

Contribution in the following 3 modules : 
- product_pricelist_direct_print, product_price_history, base_product_mass_addition

Current PSC representative : @gurneyalex 
current members : @jjscarafia, @JordiBForgeFlow, @rousseldenis 

Thanks for your feedback.
