### PR TITLE
[ADD] HaraldPanten as member of product-maintainers

### DIFF
--- a/conf/psc/product.yml
+++ b/conf/psc/product.yml
@@ -4,6 +4,7 @@ product-maintainers:
     - JordiBForgeFlow
     - rousseldenis
     - legalsylvain
+    - HaraldPanten
   name: Product maintainers
   representatives:
     - gurneyalex


### PR DESCRIPTION
Proposing Harald Panten (https://github.com/HaraldPanten) as PSC for Product repositories.

Our team has been actively involved as contributors to the OCA, consistently demonstrating our commitment to the community and its projects.