### PR TITLE
[ADD] stock-weighing repository

### DIFF
--- a/conf/psc/logistics.yml
+++ b/conf/psc/logistics.yml
@@ -19,3 +19,14 @@ logistics-maintainers-psc-representative:
     - rousseldenis
   name: Logistics maintainers psc representative
   representatives: []
+stock-weighing-maintainers:
+  members:
+    - chienandalu
+    - pedrobaeza
+  name: Stock weighing editors
+  representatives: []
+stock-weighing-maintainers-psc-representative:
+  members:
+    - pedrobaeza
+  name: Stock weighing maintainers psc representative
+  representatives: []

--- a/conf/repo/logistics.yml
+++ b/conf/repo/logistics.yml
@@ -145,6 +145,16 @@ stock-logistics-workflow:
   name: Odoo stock, workflow and organization
   psc: logistics-maintainers
   psc_rep: logistics-maintainers-psc-representative
+stock-weighing:
+  branches:
+    - "15.0"
+    - "16.0"
+    - "17.0"
+  category: Stock
+  default_branch: "15.0"
+  name: Shopfloor for weighing operations
+  psc: stock-weighing
+  psc_rep: stock-weighing-psc-representative
 wms:
   branches:
     - "10.0"


### PR DESCRIPTION
A new family of modules that serve as a weighing shopfloor assistant for bussiness workflows in which weighing the stock operations is a key process.

Please check @pedrobaeza @etobella 

cc @sergio-teruel @Tecnativa

Modules to become part of this repo (for the moment):

- [ ] https://github.com/OCA/stock-logistics-workflow/pull/1572
- [ ] https://github.com/OCA/sale-workflow/pull/3079
- [ ] https://github.com/OCA/sale-workflow/pull/3080
- [ ] https://github.com/OCA/stock-logistics-workflow/pull/1573
- [ ] https://github.com/OCA/stock-logistics-warehouse/pull/1998
- [ ] https://github.com/OCA/stock-logistics-workflow/pull/1574
- [ ] https://github.com/OCA/stock-logistics-workflow/pull/1575

![Peek 18-04-2024 13-01](https://github.com/OCA/repo-maintainer-conf/assets/5040182/223d05dd-cdbf-454d-b408-d641a0cce136)
