### PR TITLE
Add web-api-contrib repo

### DIFF
--- a/conf/repo/web.yml
+++ b/conf/repo/web.yml
@@ -28,3 +28,14 @@ web-api:
   name: Web Api
   psc: board
   psc_rep: board
+web-api-contrib:
+  branches:
+    - "14.0"
+    - "15.0"
+    - "16.0"
+    - "17.0"
+  category: Web
+  default_branch: "14.0"
+  name: Web API contrib
+  psc: board
+  psc_rep: board


### PR DESCRIPTION
Originated from this discussion https://github.com/OCA/product-attribute/pull/1645#discussion_r1654672188.
Similarly to `mis-builder-contrib` this repo should host modules that extend `web-api` features but they are not generic and not part of core set of modules.