### PR TITLE
[ADD] l10n/brazil: add antoniospneto as member

### DIFF
--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -52,6 +52,7 @@ local-brazil-maintainers:
     - renatonlima
     - mileo
     - marcelsavegnago
+    - antoniospneto
   name: Local brazil maintainers
   representatives: []
 local-brazil-maintainers-psc-representative:


### PR DESCRIPTION
Hello OCA maintainers,

@renatonlima and myself would like to promote Antonio Neto @antoniospneto from the Brazilian Engenere company as a PSC for the `OCA/l10n-brazil` repo.

Antonio has been doing **excellent contributions** over the last 3 years: 
https://github.com/OCA/l10n-brazil/graphs/contributors

- over: 364+ quality commits
- 148+ merged PRs https://github.com/OCA/l10n-brazil/pulls?q=is%3Apr+is%3Amerged+author%3Aantoniospneto
- countless quality reviews
- authored a couple new modules
- contributed PRs on other OCA repos
- overall he helped a lot (fixed hard issues, found complex issues during reviews) with the l10n_br_fiscal module, the l10n_br_account module, the banking boleto/CNAB modules and many other modules.
- he has a good knowledge how open source works
- helped a lot during the v14, v15 and v16 migrations.

It is worth mentioning that OCA/l10n-brazil is simply the largest of all the OCA repos (both in term of code with over 130k lines of Python+XML and in term of commits with over 13k commits, making it weight as much as 10% of Odoo CE...) so we cannot accept anyone as a PSC even with hundred of commits as the responsibility is so huge in such a huge repo. But over the last 3 years @antoniospneto definitely reached the skills and contributions to be one more PSC of the project.

cc the 3 other PSC's: @renatonlima @marcelsavegnago @mileo 
and 2 other of the current top contributors: @mbcosta @felipemotter 