### PR TITLE
[ADD] HaraldPanten as member of human-maintainers

### DIFF
--- a/conf/psc/human.yml
+++ b/conf/psc/human.yml
@@ -6,6 +6,7 @@ human-resources-maintainers:
     - feketemihai
     - nimarosa
     - Saran440
+    - HaraldPanten
   name: Human resources maintainers
   representatives:
     - dreispt


### PR DESCRIPTION
Proposing Harald Panten (https://github.com/HaraldPanten) as PSC for Human Resources repositories.

These repositories could benefit from Sygel's team experience and dedication to OCA. Our commitment to the community and its projects is exemplified by Harald's active involvement as a contributor to the OCA.

@HaraldPanten