### PR TITLE
Remove archived repo maintainer-quality-tools

### DIFF
--- a/conf/repo/maintainer.yml
+++ b/conf/repo/maintainer.yml
@@ -1,10 +1,3 @@
-maintainer-quality-tools:
-  branches: []
-  category: Maintainer
-  default_branch: master
-  name: Qa tools for odoo maintainers
-  psc: community-maintainers
-  psc_rep: community-maintainers-psc-representative
 maintainer-tools:
   branches: []
   category: Maintainer


### PR DESCRIPTION
Shall we archive and remove https://github.com/OCA/runbot-addons too?