### PR TITLE
[ADD] mail repo + psc

### DIFF
--- a/conf/psc/mail.yml
+++ b/conf/psc/mail.yml
@@ -1,0 +1,16 @@
+mail-maintainers:
+  members:
+    - yajo
+    - antespi
+    - hbrunn
+    - pedrobaeza
+    - rafaelbn
+    - etobella
+  name: Mail maintainers
+  representatives:
+    - simahawk
+mail-maintainers-psc-representative:
+  members:
+    - hbrunn
+  name: Mail maintainers psc representative
+  representatives: []

--- a/conf/repo/mail.yml
+++ b/conf/repo/mail.yml
@@ -1,0 +1,8 @@
+mail:
+  branches:
+    - "18.0"
+  category: Mail
+  default_branch: "18.0"
+  name: Addons related to odoo's messaging features
+  psc: mail-maintainers
+  psc_rep: mail-maintainers-psc-representative


### PR DESCRIPTION
As per [a suggestion from @pedrobaeza that received a lot of positive feedback](https://github.com/OCA/social/issues/1458#issuecomment-2427476407), here is the PR to create new repo `oca/mail` that will focus on addons related to odoo's messaging features

@simahawk 