### PR TITLE
Request to add  ayushin to tools-maintainer

### DIFF
--- a/conf/psc/tools.yml
+++ b/conf/psc/tools.yml
@@ -10,6 +10,7 @@ tools-maintainers:
     - pedrobaeza
     - LoisRForgeFlow
     - joao-p-marques
+    - ayushin
   name: Tools maintainers
   representatives:
     - simahawk


### PR DESCRIPTION
I'd like to take over the [ansible-odoo](https://github.com/OCA/ansible-odoo) and potentially also convert https://github.com/smartops-aero/smartops-odoo-flight into OCA

Ref https://github.com/OCA/ansible-odoo/issues/113