### PR TITLE
Add dedicated PSC for oca/queue

### DIFF
--- a/conf/psc/connector.yml
+++ b/conf/psc/connector.yml
@@ -47,7 +47,6 @@ connector-maintainers:
   name: Connector maintainers
   representatives:
     - simahawk
-    - sbidoul
     - gurneyalex
 connector-maintainers-psc-representative:
   members:

--- a/conf/psc/queue.yml
+++ b/conf/psc/queue.yml
@@ -1,0 +1,14 @@
+queue-maintainers:
+  members:
+    - guewen
+    - lmignon
+  name: Asynchronous job queue maintainers
+  representatives:
+    - simahawk
+    - sbidoul
+    - gurneyalex
+queue-maintainers-psc-representative:
+  members:
+    - guewen
+  name: Asynchronous job queue maintainers psc representative
+  representatives: []

--- a/conf/repo/queue.yml
+++ b/conf/repo/queue.yml
@@ -12,5 +12,5 @@ queue:
   category: Queue
   default_branch: "16.0"
   name: Asynchronous job queue
-  psc: connector-maintainers
-  psc_rep: connector-maintainers-psc-representative
+  psc: queue-maintainers
+  psc_rep: queue-maintainers-psc-representative


### PR DESCRIPTION
The connector PSC is too broad. Maintainers of the queue project (like me) don't necessarily want to be PSC of, say, connector-ecommerce.

So I propose to split out a dedicated PSC for the oca/queue project.