### PR TITLE
[ADD] Logistics: Release Channel, Reservation and Shopfloor repositories

### DIFF
--- a/conf/repo/logistics.yml
+++ b/conf/repo/logistics.yml
@@ -80,6 +80,16 @@ stock-logistics-request:
     stock needs by product and location.
   psc: logistics-maintainers
   psc_rep: logistics-maintainers-psc-representative
+stock-logistics-release-channel:
+  branches:
+    - "18.0"
+  category: Stock
+  default_branch: "18.0"
+  name: This repository contains modules to manage release channels.
+    Release channels represent a way of grouping deliveries and their
+    pickings in order to enhance resource management in the warehouse.
+  psc: logistics-maintainers
+  psc_rep: logistics-maintainers-psc-representative
 stock-logistics-tracking:
   branches:
     - "6.1"

--- a/conf/repo/logistics.yml
+++ b/conf/repo/logistics.yml
@@ -90,6 +90,23 @@ stock-logistics-release-channel:
     pickings in order to enhance resource management in the warehouse.
   psc: logistics-maintainers
   psc_rep: logistics-maintainers-psc-representative
+stock-logistics-reservation:
+  branches:
+    - "18.0"
+  category: Stock
+  default_branch: "18.0"
+  name: This repository contains modules related to products reservations.
+  psc: logistics-maintainers
+  psc_rep: logistics-maintainers-psc-representative
+stock-logistics-shopfloor:
+  branches:
+    - "18.0"
+  category: Stock
+  default_branch: "18.0"
+  name: This repository contains modules to manage Shopfloor application.
+    That application allows to manage all logistics flows as a mobile one.
+  psc: logistics-maintainers
+  psc_rep: logistics-maintainers-psc-representative
 stock-logistics-tracking:
   branches:
     - "6.1"


### PR DESCRIPTION
@OCA/logistics-maintainers 

Before first PR's creation in 18.0 repository and because modules amount in that field are quite important, I suggest to create a separate repository for release channel management.

See: https://github.com/OCA/wms