### PR TITLE
[ADD] sale-prebook repository

### DIFF
--- a/conf/psc/sale.yml
+++ b/conf/psc/sale.yml
@@ -12,3 +12,17 @@ sale-blanket-maintainers-psc-representative:
     - jbaudoux
   name: Sales blanket maintainers psc representative
   representatives: []
+sale-prebook-maintainers:
+  members:
+    - jbaudoux
+    - rousseldenis
+    - lmignon
+  name: Sales prebook maintainers
+  representatives:
+    - jbaudoux
+    - rousseldenis
+sale-prebook-maintainers-psc-representative:
+  members:
+    - jbaudoux
+  name: Sales prebook maintainers psc representative
+  representatives: []

--- a/conf/repo/sale.yml
+++ b/conf/repo/sale.yml
@@ -91,3 +91,18 @@ sale-blanket:
   name: Sales blanket order
   psc: sale-blanket-maintainers
   psc_rep: sale-blanket-maintainers-psc-representative
+sale-prebook:
+  branches:
+    - "14.0"
+    - "16.0"
+    - "17.0"
+    - "18.0"
+  category: Sale
+  default_branch: "16.0"
+  name: Sales order's stock prebooking
+
+    This repository provides addons for stock prebooking in sales orders. Unlike
+    default Odoo, it enables stock reservation before order confirmation and
+    integrates this feature into related processes.
+  psc: sale-prebook-maintainers
+  psc_rep: sale-prebook-maintainers-psc-representative


### PR DESCRIPTION
This repository provides addons for stock prebooking in sales orders. Unlike default Odoo, it enables stock reservation before order confirmation and integrates this feature into related processes.