### PR TITLE
[ADD] HaraldPanten as member of logistics

### DIFF
--- a/conf/psc/logistics.yml
+++ b/conf/psc/logistics.yml
@@ -10,6 +10,7 @@ logistics-maintainers:
     - rousseldenis
     - LoisRForgeFlow
     - ps-tubtim
+    - HaraldPanten
   name: Logistics maintainers
   representatives:
     - simahawk


### PR DESCRIPTION
Proposing Harald Panten (https://github.com/HaraldPanten) as PSC for Logistics repositories.

Our team has been actively involved as contributors to the OCA, consistently demonstrating our commitment to the community and its projects.
@HaraldPanten 