### PR TITLE
[ADD] Shide as maintainer of Logistics

### DIFF
--- a/conf/psc/logistics.yml
+++ b/conf/psc/logistics.yml
@@ -10,6 +10,7 @@ logistics-maintainers:
     - rousseldenis
     - LoisRForgeFlow
     - ps-tubtim
+    - Shide
   name: Logistics maintainers
   representatives:
     - simahawk


### PR DESCRIPTION
Hello,
my name is Eduardo de Miguel, and I want to propose @Shide (myself) to be a PSC for Logistics repositories.

I'm part of the @moduon team, and I am actively contributing in several of the logistics group's repositories. 
Together with my colleagues at Moduon Team, we analyze, improve, and develop new useful and very well integrated products in this specific area.

You can see my contributions to:
- [Delivery Carrier](https://github.com/OCA/delivery-carrier/pulls?q=author%3AShide)
- [Stock Logistics Reporting](https://github.com/OCA/stock-logistics-reporting/pulls?q=author%3AShide)
- [Stock Logistics Warehouse](https://github.com/OCA/stock-logistics-warehouse/pulls?q=author%3AShide)
- [Stock Logistics Workflow](https://github.com/OCA/stock-logistics-workflow/pulls?q=author%3AShide)

I believe my experience and contributions can help further improve the Logistics projects, and I would love the opportunity to take on more responsibility within the PSC. Please let me know if you need any additional information to support my application.

@OCA/logistics-maintainers