### PR TITLE
Add myself as Core Maintainer

### DIFF
--- a/conf/psc/core.yml
+++ b/conf/psc/core.yml
@@ -9,6 +9,7 @@ core-maintainers:
     - yvaucher
     - moylop260
     - pedrobaeza
+    - etobella
   name: Core maintainers
   representatives:
     - simahawk


### PR DESCRIPTION
After many years as one of the Top 10 contributors on the OCA, I think I can opt for core contributor.

![image](https://github.com/user-attachments/assets/d851d3c2-c5e2-4e70-a700-17c4fe41858c)

On average, I review 34 PRs every month and 13 are merged made by me. Also, as you can check on the graphs, my collaboration is consistent.

My work is not related to a single repository, as I work a lot of them:

- OWL (web, automation, VOIP)
- OpenUpgrade (mainly improve on speed)
- Accouting
- Maintenance
- EDI


