### PR TITLE
Split EDI repo (?)

### DIFF
--- a/conf/repo/edi.yml
+++ b/conf/repo/edi.yml
@@ -13,7 +13,39 @@ edi:
     - "18.0"
   category: Edi
   default_branch: "18.0"
-  name: Edi
+  name: EDI generic modules
+  psc: edi-maintainers
+  psc_rep: edi-maintainers-psc-representative
+edi-sale:
+  branches:
+    - "18.0"
+  category: Edi
+  default_branch: "18.0"
+  name: EDI Sale modules
+  psc: edi-maintainers
+  psc_rep: edi-maintainers-psc-representative
+edi-purchase:
+  branches:
+    - "18.0"
+  category: Edi
+  default_branch: "18.0"
+  name: EDI Purchase modules
+  psc: edi-maintainers
+  psc_rep: edi-maintainers-psc-representative
+edi-stock:
+  branches:
+    - "18.0"
+  category: Edi
+  default_branch: "18.0"
+  name: EDI Stock modules
+  psc: edi-maintainers
+  psc_rep: edi-maintainers-psc-representative
+edi-account:
+  branches:
+    - "18.0"
+  category: Edi
+  default_branch: "18.0"
+  name: EDI Stock modules
   psc: edi-maintainers
   psc_rep: edi-maintainers-psc-representative
 edi-framework:


### PR DESCRIPTION
The EDI repo is quite big and has a huge scope... Shall we take the chance to split it while on v18 there's no specific module migrated?

@OCA/edi-maintainers 