### PR TITLE
[ADD] Edi Ediversa Repository

### DIFF
--- a/conf/repo/edi.yml
+++ b/conf/repo/edi.yml
@@ -28,3 +28,12 @@ edi-framework:
   name: Edi Framework
   psc: edi-framework-maintainers
   psc_rep: edi-framework-maintainers-psc-representative
+edi-ediversa:
+  branches:
+    - "17.0"
+    - "18.0"
+  category: Edi
+  default_branch: "18.0"
+  name: Edi Ediversa
+  psc: edi-maintainers
+  psc_rep: edi-maintainers-psc-representative


### PR DESCRIPTION
Following the conversation held in this PR (https://github.com/OCA/edi/pull/1163#issuecomment-3069224131), I am proposing the opening of an EDI sub-repository for the ediversa supplier.

On the other hand, I've been reviewing the discussion about separating the EDI repository, but it was ultimately discarded (https://github.com/OCA/repo-maintainer-conf/pull/99). For my part, I see sense in creating sub-repositories, since otherwise, there would be a very large single repository. It makes sense to leave the EDI repository for generic things, and on the other hand, the sub-repositories for each supplier. For external searches, it's possibly better too.