### PR TITLE
Propose sbejaoui as RMA PSC

### DIFF
--- a/conf/psc/logistics.yml
+++ b/conf/psc/logistics.yml
@@ -10,6 +10,7 @@ logistics-maintainers:
     - rousseldenis
     - LoisRForgeFlow
     - ps-tubtim
+    - sbejaoui
   name: Logistics maintainers
   representatives:
     - simahawk


### PR DESCRIPTION
I would like to apply for the PSC role for the RMA repository.

Over the last months, I have been actively contributing to the RMA repository, working on several improvements to the base module to provide a more flexible and configurable workflow depending on the operation. I have also introduced new modules that add important features, such as RMA reasons, lot/serial number tracking, and I am currently working on the integration between RMA and the repair module.

I believe I can contribute to maintaining and evolving this stack by reviewing, testing, and supporting new contributors.

You can find my PRs here: https://github.com/OCA/rma/pulls/sbejaoui

@OCA/logistics-maintainers 