### PR TITLE
Propose flotho as Infrastructure Maintainer PSC

### DIFF
--- a/conf/psc/infrastructure.yml
+++ b/conf/psc/infrastructure.yml
@@ -1,4 +1,5 @@
 infrastructure-maintainer:
-  members: []
+  members:
+    - flotho
   name: Maintainer of the infrastructure repositories
   representatives: []


### PR DESCRIPTION
Hello 👋🏻

I'd like to propose myself as a maintainer of the infrastructure-maintainers team.

I currently rewrite the v16 infrastructure dns https://github.com/OCA/infrastructure/pull/20  module  and about to port it in v18 

I currently contribute on other modules like connector prestashop, connector odoo2odoo,

As CEO of @MindAndGo we're deploying and hosting various Odoo version always deployed with all the set of OCA Repos.

I believe I can help move things forward by assisting with reviews of FIX and IMP pull requests, as well as supporting current and future migrations.

Thanks for considering my application.

Best regards,
Florent THOMAS
GitHub: [flotho](https://github.com/flotho)