### PR TITLE
[ADD] module-composition-analysis repository and PSC

### DIFF
--- a/conf/psc/module-composition-analysis.yml
+++ b/conf/psc/module-composition-analysis.yml
@@ -1,0 +1,12 @@
+module-composition-analysis-maintainers:
+  members:
+    - sebalix
+    - hparfr
+  name: Module Composition Analysis maintainers
+  representatives:
+    - sebalix
+module-composition-analysis-maintainers-psc-representative:
+  members:
+    - sebalix
+  name: Module Composition Analysis psc representaive
+  representatives: []

--- a/conf/repo/module-composition-analysis.yml
+++ b/conf/repo/module-composition-analysis.yml
@@ -1,0 +1,11 @@
+module-composition-analysis:
+  branches:
+    - "16.0"
+    - "17.0"
+    - "18.0"
+    - "19.0"
+  category: Module Composition Analysis
+  default_branch: "16.0"
+  name: Module Composition Analysis
+  psc: module-composition-analysis-maintainers
+  psc_rep: module-composition-analysis-maintainers-psc-representative


### PR DESCRIPTION
Following my email on [Contributors mailing list](https://odoo-community.org/groups/contributors-15/contributors-2155064?mode=thread&date_begin=&date_end=), now that the repository has been moved under the OCA organization, here is the PR to configure the repository properly.

OCA repo:
- https://github.com/OCA/odoo-repository (now renamed https://github.com/OCA/module-composition-analysis)

This repository implements modules that are collecting Odoo modules data (from scanned repositories like OCA, Odoo, private...), then on top of them we can declare Odoo projects using such modules, and generate migration reports, upgrade changelogs based on git history, etc.

Now I always found the name awkward, so if anyone has a better name for such repository, it's time to change it!

=> renamed `module-composition-analysis` :heavy_check_mark: 