### PR TITLE
[ADD] l10n-australia: repository and initial PSC teams

### DIFF
--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -12,6 +12,17 @@ local-austria-maintainers:
     - wtaferner
   name: Local austria maintainers
   representatives: []
+local-australia-maintainers:
+  members:
+    - JhonRomero26
+    - gdgellatly
+  name: Local australia maintainers
+  representatives: []
+local-australia-maintainers-psc-representative:
+  members:
+    - gdgellatly
+  name: Local australia maintainers psc representative
+  representatives: []
 local-austria-maintainers-psc-representative:
   members:
     - wtaferner

--- a/conf/repo/l10n.yml
+++ b/conf/repo/l10n.yml
@@ -35,6 +35,15 @@ l10n-austria:
   name: Odoo austria localization
   psc: local-austria-maintainers
   psc_rep: local-austria-maintainers-psc-representative
+l10n-australia:
+  branches:
+    - "18.0"
+    - "19.0"
+  category: L10n
+  default_branch: "18.0"
+  name: Odoo Australia localization
+  psc: local-australia-maintainers
+  psc_rep: local-australia-maintainers-psc-representative
 l10n-belarus:
   branches:
     - "11.0"


### PR DESCRIPTION
Following the suggestion by @rousseldenis in the discussion [https://github.com/orgs/OCA/discussions/254](https://github.com/orgs/OCA/discussions/254), I am proposing the creation of the l10n-australia repository and its initial PSC.

I have included @gdgellatly as a member and PSC representative given his extensive experience in the Australian region, as recommended. I am looking forward to collaborating with him and the rest of the community to build a robust open-source localization for Australia.

# Australian Localization
I would like to propose the creation of a new repository: l10n-australia. Currently, Odoo Community Edition only provides the base l10n_au module. Many critical features for the Australian market are locked under Enterprise or are missing entirely, creating a significant gap for community users and small businesses in the region.

## Rationale 
Australia has specific accounting and compliance requirements that are not currently covered by OCA repositories. Specifically, the following features are needed in a community-driven environment:

- **Bank Payments (ABA):** An open-source implementation of the Australian Bankers Association (ABA) file format for batch payments.
- **Financial Reporting:** Templates for MIS Builder to provide Profit & Loss, Balance Sheet, and Business Activity Statement (BAS) according to Australian standards.
- **Tax Compliance:** Advanced GST handling and reporting.
- **Payroll logic:** While complex, a foundation for local payroll rules (Superannuation, PAYG) would be highly beneficial.