### PR TITLE
Rename interface-github to interface-git

### DIFF
--- a/conf/repo/interface.yml
+++ b/conf/repo/interface.yml
@@ -1,4 +1,4 @@
-interface-github:
+interface-git:
   branches:
     - "8.0"
     - "10.0"
@@ -13,6 +13,6 @@ interface-github:
     - "19.0"
   category: Interface
   default_branch: "18.0"
-  name: Tools to interact with github from odoo
+  name: Tools to interact with git (GitHub/Gitlab) from Odoo
   psc: tools-maintainers
   psc_rep: tools-maintainers-psc-representative


### PR DESCRIPTION
For integrating other tools related to other platforms based on Git, like Gitlab.

Discussion in https://github.com/OCA/interface-github/issues/137.

@Tecnativa 