### PR TITLE
[UPD] l10n-spain: Set 19.0 as default branch

### DIFF
--- a/conf/repo/l10n.yml
+++ b/conf/repo/l10n.yml
@@ -718,7 +718,7 @@ l10n-spain:
     - "18.0"
     - "19.0"
   category: L10n
-  default_branch: "18.0"
+  default_branch: "19.0"
   name: Odoo spain localization
   psc: local-spain-maintainers
   psc_rep: local-spain-maintainers-psc-representative


### PR DESCRIPTION
Update default branch to 19.0 for l10n-spain repository

@HaraldPanten @pedrobaeza 