### PR TITLE
Propose sbejaoui as edi PSC

### DIFF
--- a/conf/psc/edi.yml
+++ b/conf/psc/edi.yml
@@ -23,6 +23,7 @@ edi-maintainers:
     - hbrunn
     - etobella
     - jbaudoux
+    - sbejaoui
   name: Edi maintainers
   representatives:
     - simahawk


### PR DESCRIPTION
I would like to apply for the PSC role for the edi repository

Over the last months, I have been actively contributing to the repository, mainly around UBL/CII import and Peppol workflows. I contributed several modules and improvements related to supplier invoice import, purchase matching, tax retrieval, packaging/UNECE handling, and overall import reliability

I would be happy to help maintain and evolve the repository, as well as forward-porting the work done on 16.0 to newer versions

You can find my PRs here: https://github.com/OCA/edi/pulls/sbejaoui

cc/ @OCA/edi-maintainers 