### PR TITLE
Add PeleOlala to local-ukraine maintainers

### DIFF
--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -508,6 +508,7 @@ local-uk-maintainers:
 local-ukraine-maintainers:
   members:
     - alexey-pelykh
+    - PeleOlala
   name: Local ukraine maintainers
   representatives: []
 local-ukraine-maintainers-psc-representative:


### PR DESCRIPTION
This PR proposes adding myself as a co-maintainer of
OCA/l10n-ukraine alongside @alexey-pelykh.

Context:

- The repository has been mostly dormant for some time
  (no merged PRs in 2024-2025, several PRs from 2022-2023
  awaiting review).
- I have opened OCA/l10n-ukraine#18 (DK 003:2010 occupations
  classifier, CI green) and a roadmap in OCA/l10n-ukraine#19
  outlining a Ukrainian HR + e-forms ecosystem with 10+
  planned modules. Crossposts in OCA Discord
  (#contract-hr-account, #general) led to this path
  through guidance from @adamheinz — thank you!
- ICLA submitted, pending confirmation.

This is co-maintainership, not replacement. @alexey-pelykh
remains in the team. I'm available to handle reviews and
help re-activate the Ukrainian localization stack.

cc @alexey-pelykh for awareness and approval if appropriate.