### PR TITLE
Remove 'yajo' from OpenUpgrade maintainers

### DIFF
--- a/conf/psc/openupgrade.yml
+++ b/conf/psc/openupgrade.yml
@@ -1,6 +1,5 @@
 openupgrade-maintainers:
   members:
-    - yajo
     - StefanRijnhart
     - hbrunn
     - legalsylvain


### PR DESCRIPTION
He's no active in this repo since early 2021:

https://github.com/OCA/OpenUpgrade/issues?q=is%3Apr%20state%3Aclosed%20author%3A%40yajo

@Tecnativa 