### PR TITLE
connector: add connector-shopify repository

### DIFF
--- a/conf/psc/connector.yml
+++ b/conf/psc/connector.yml
@@ -109,8 +109,7 @@ connector-shopify-maintainers-psc-representative:
   members:
     - sawirricardo
   name: Connector shopify maintainers psc representative
-  representatives:
-    - sawirricardo
+  representatives: []
 connector-woocommerce-maintainers:
   members: []
   name: Connector woocommerce maintainers

--- a/conf/psc/connector.yml
+++ b/conf/psc/connector.yml
@@ -99,6 +99,18 @@ connector-telephony-maintainers-psc-representative:
     - alexis-via
   name: Connector telephony maintainers psc representative
   representatives: []
+connector-shopify-maintainers:
+  members:
+    - sawirricardo
+  name: Connector shopify maintainers
+  representatives:
+    - sawirricardo
+connector-shopify-maintainers-psc-representative:
+  members:
+    - sawirricardo
+  name: Connector shopify maintainers psc representative
+  representatives:
+    - sawirricardo
 connector-woocommerce-maintainers:
   members: []
   name: Connector woocommerce maintainers

--- a/conf/repo/connector.yml
+++ b/conf/repo/connector.yml
@@ -294,6 +294,14 @@ connector-salesforce:
   name: Connect salesforce with odoo
   psc: connector-saleforce-maintainers
   psc_rep: board
+connector-shopify:
+  branches:
+    - "19.0"
+  category: Connector
+  default_branch: "19.0"
+  name: Connector Shopify
+  psc: connector-shopify-maintainers
+  psc_rep: connector-shopify-maintainers-psc-representative
 connector-spscommerce:
   branches:
     - "9.0"


### PR DESCRIPTION
## New repository proposal: connector-shopify

No maintained open-source Shopify connector exists in the OCA today (WooCommerce, Magento, and PrestaShop all have one). Shopify's quarterly API versioning makes shared maintainership the only sustainable model for such a connector — a natural fit for the OCA.

**Working code ready to migrate:** https://github.com/sawirstudio/shopify-odoo-connector (AGPL-3, Odoo 19.0, CI green: ruff + pylint-odoo + standalone pytest + full TransactionCase suites against Odoo 19 and OCA queue_job)

Three modules, GraphQL Admin API (2026-01) only:

- `shopify_connector` — instances, cost-aware GraphQL client, HMAC webhook intake with dedupe + reconcile crons, bidirectional products/variants/images/collections with per-field ownership, multi-location inventory (race-safe `inventorySetQuantities` with compareQuantity), customers with dedup + Shopify Plus B2B (companies, catalogs → pricelists), full order lifecycle (edits, cancellations, partial refunds → credit notes, draft orders, risk holds, per-instance tax mapping, gateway journals), fulfillment push via Fulfillment Orders API, onboarding wizard, sync dashboard, error mass-retry, dedicated queue_job channels.
- `shopify_connector_account` — Shopify Payments payout + dispute import; balanced draft journal entry generation with typed mismatch errors (never a forced balancing line).
- `shopify_connector_pos` — Shopify POS order routing, immediate fulfillment, cash rounding.

A quarterly Shopify API version upgrade runbook is documented in-repo, and I commit to maintainership.

ICLA submitted 2026-07-29 (GitHub: @sawirricardo).
