### PR TITLE
[IMP] Add l10n-panama repository and its maintainers

### DIFF
--- a/conf/psc/l10n.yml
+++ b/conf/psc/l10n.yml
@@ -378,6 +378,16 @@ local-norway-maintainers-psc-representative:
     - bringsvor
   name: Local norway maintainers psc representative
   representatives: []
+local-panama-maintainers:
+  members:
+    - alvarosamudio
+  name: Local panama maintainers
+  representatives: []
+local-panama-maintainers-psc-representative:
+  members:
+    - alvarosamudio
+  name: Local panama maintainers psc representative
+  representatives: []
 local-peru-maintainers:
   members:
     - pedrobaeza

--- a/conf/repo/l10n.yml
+++ b/conf/repo/l10n.yml
@@ -591,6 +591,14 @@ l10n-norway:
   name: The norwegian localization for odoo
   psc: local-norway-maintainers
   psc_rep: local-norway-maintainers-psc-representative
+l10n-panama:
+  branches:
+    - "19.0"
+  category: L10n
+  default_branch: "19.0"
+  name: Panama localization repository
+  psc: local-panama-maintainers
+  psc_rep: local-panama-maintainers-psc-representative
 l10n-peru:
   branches:
     - "7.0"


### PR DESCRIPTION
This PR requests the creation of the **OCA/l10n-panama** repository (branch `19.0`) to host the Panama localization modules, following the [Create a new repository](https://github.com/OCA/maintainer-tools/wiki/Create-a-new-repository) procedure.

## What is included
- `conf/repo/l10n.yml`: new `l10n-panama` repository entry (`category: L10n`, default branch `19.0`, PSC `local-panama-maintainers`, PSC representative `local-panama-maintainers-psc-representative`).
- `conf/psc/l10n.yml`: new PSC `local-panama-maintainers` and its representative, member **alvarosamudio**.

## First module to host
`l10n_pa` (Panama - Accounting), already prepared following OCA conventions (AGPL-3, README, headers, LICENSE), covering the current Panamanian regulations:
- ITBMS general rate and exemptions (Ley 31 de 1998, Ley 8 de 2010).
- ISR 25%, withholdings and dividend taxes (Código Fiscal, Ley 52 de 2012).
- 50% ITBMS retention for Large Buyers (Decreto Ejecutivo 173/2021, 84/2005).
- RUC and official postal code validation (Correos Panamá/COTEL, 2026).

Once merged, the module will be pushed and its review PR opened in the new repository.
